### PR TITLE
Remove duplicate "git add --all ." command

### DIFF
--- a/git.sh
+++ b/git.sh
@@ -11,9 +11,8 @@ function banner() {
 
 banner "Checking for newer files online."
 git pull
-# Below command will backup everything inside the project folder
-git add --all .
 
+# Below command will backup everything inside the project folder
 banner "Backing up everything in project folder."
 git add --all .
 


### PR DESCRIPTION
The command was called twice, with only a banner function call in between.

This is the first time that I'm contributing to a forked project, so please accept my apologies in advance if I did not follow the correct procedure.