### PR TITLE
Use `term_cols` variable in `for` loops

### DIFF
--- a/git.sh
+++ b/git.sh
@@ -3,9 +3,9 @@
 function banner() {
 	term_cols=$(tput cols) 
 	str=":: $1 ::"
-	for ((i=1; i<=`tput cols`; i++)); do echo -n ‾; done
+	for ((i=1; i<=$term_cols; i++)); do echo -n ‾; done
 	tput setaf 10; printf "%*s\n" $(((${#str}+$term_cols)/2)) "$str"; tput sgr0
-	for ((i=1; i<=`tput cols`; i++)); do echo -n _; done
+	for ((i=1; i<=$term_cols; i++)); do echo -n _; done
 	printf "\n"
 }
 


### PR DESCRIPTION
The two `for` loops that draw the horizontal lines execute the `tput cols` command on each iteration. This change uses the `term_cols` variable that was already set to the correct value.

For testing the `banner` function, I used the following test script:

```shell script
#!/bin/bash

function banner() {
        term_cols=$(tput cols) 
        str=":: $1 ::"
        for ((i=1; i<=$term_cols; i++)); do echo -n ‾; done
        tput setaf 10; printf "%*s\n" $(((${#str}+$term_cols)/2)) "$str"; tput sgr0
        for ((i=1; i<=$term_cols; i++)); do echo -n _; done
        printf "\n"
}

banner "Checking for newer files online."
banner "Backing up everything in project folder."
banner "Enter your commit message (optional)"
banner "Committing to the local repository."
banner "Pushing local files to Github."
banner "Git push completed...all done!"
```

Running the following on the modified version of the `banner` function (using $term_cols variable)

```
time ./git.sh
```

produced the following results:

```
real    0m0.047s
user    0m0.026s
sys     0m0.022s
```

Without the change (the original script in other words, minus the git commands), took much longer. Here is the result:

```
real    0m1.345s
user    0m0.846s
sys     0m0.476s
```

As you can see, there is a significant efficiency gain by using the `term_cols` variable over running the `tput cols` command in the `for` loops.

I trust that this pull request meets with your approval.

PS. I love your `banner` function!
